### PR TITLE
mitigate GNU parallel issues on NFS

### DIFF
--- a/run_topsstack.cwl
+++ b/run_topsstack.cwl
@@ -9,6 +9,7 @@ arguments:
 - -c
 - if [ ! -d $HOME/topsstack_hamsar ]; then cp -r /home/jovyan/topsstack_hamsar $HOME/; fi &&
   if [ ! -d $HOME/.ipython ]; then cp -r /home/jovyan/.ipython $HOME/ || true ; fi &&
+  if [ ! -d $HOME/.parallel ]; then mkdir -p /home/jovyan/.parallel; ln -sf /home/jovyan/.parallel $HOME/.parallel; fi &&
   /opt/conda/bin/papermill $(inputs.input_nb) $(inputs.output_nb) 
    -p min_lat '$(inputs.min_lat)'
    -p max_lat '$(inputs.max_lat)'


### PR DESCRIPTION
Need `~/.parallel` to be owned by the UID:GID of the pod but when PVC is backed by NFS, UID:GID of dirs/files created by user is different.
Adding this line will ensure that the `~/.parallel` directory is owned by the UID:GID of the pod because we use the local filesystem.